### PR TITLE
Update docgen-action to latest commit in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           use-github-cache: false
 
       - name: Compile blueprint and documentation
-        uses: leanprover-community/docgen-action@b210116d3e6096c0c7146f7a96a6d56b6884fef5 # 2025-06-12
+        uses: leanprover-community/docgen-action@f78d5a9a1a728288aef64bde6f133d30a8511cb7 # 2025-06-27
         with:
           blueprint: true
           homepage: home_page


### PR DESCRIPTION
Bump leanprover-community/docgen-action from commit b210116d to f78d5a9a in the GitHub Actions workflow to use the latest improvements and fixes.